### PR TITLE
Adding guidance for minor changes to the standard

### DIFF
--- a/pmix_governance.tex
+++ b/pmix_governance.tex
@@ -466,6 +466,9 @@ and \ref{proposed-modification} and then bring the
 changes to the attention of the ASC Co-Chairs and Release Managers.
 The Co-Chairs and Release Managers will evaluate the proposed
 changes to determine whether they are minor or substantive.
+Additionally, all PMIx participants are encouranged to examine
+and comment on the changes in the pull request to aid the
+Co-Chairs and Release Managers in their decision.
 If all Co-Chairs and Release Managers determine that the
 changes are minor and do not alter the meaning of the current standard text, 
 then the changes do not require the full process and

--- a/pmix_governance.tex
+++ b/pmix_governance.tex
@@ -449,6 +449,33 @@ alterations of text that result in changed meaning or clarifications. The
 Release Managers will prioritize major releases of the standard over waiting for
 additional changes that are in progress but not yet accepted by the ASC.
 
+\hypertarget{administrative-changes-guidance}{%
+\subsubsection{Minor Document Changes Guidance}\label{administrative-changes-guidance}}
+The intention of the rigorous process outlined in 
+Section~\ref{the-standardization-process} for proposed
+changes to the PMIx Standard is to ensure quality and consistency of 
+the interface and the overall document. However, in some cases, 
+PMIx participants may propose minor changes to the document that 
+should not require the full process required for substantive changes. 
+Examples of these minor changes include fixes for typographical errors 
+(``typos''), missing or erroneous punctuation, and formatting changes.
+
+In the case minor changes are proposed, the proposer should 
+create an issue and pull request as described in Sections~\ref{initial-discussion}
+and \ref{proposed-modification} and then bring the
+changes to the attention of the ASC Co-Chairs and Release Managers.
+The Co-Chairs and Release Managers will evaluate the proposed
+changes to determine whether they are minor or substantive.
+If all Co-Chairs and Release Managers determine that the
+changes are minor and do not alter the meaning of the current standard text, 
+then the changes do not require the full process and
+the changes can be applied to the document in the next release.
+Alternatively, if any of the Co-Chairs or Release Managers determine 
+that the changes do or could alter the meaning of the current standard text, 
+the changes will be handled using the full rigorous process
+as described in Section~\ref{the-standardization-process}.
+
+
 
 \hypertarget{the-standardization-process}{%
 \subsection{The Standardization


### PR DESCRIPTION
Proposal to add guidance to the governance document to describe the reduced process for minor ("typo", formatting) changes to the standard document. The idea is that these changes could be reviewed by the ASC chairs and release managers and simply included in the next release without requiring readings and voting.