### PR TITLE
Clarification to governance document for quarterly meeting timeline (R2)

### DIFF
--- a/pmix_governance.tex
+++ b/pmix_governance.tex
@@ -231,19 +231,18 @@ The Co-Chairs shall include links to each proposed modification to the
 Standard up for consideration during that meeting in the published
 agenda.
 
-ASC quarterly meeting agenda items must be submitted to the Co-Chairs
-at least four weeks in advance of the meeting. Four weeks in advance of
+ASC quarterly meeting agenda items for reading and vote must be submitted to the Co-Chairs
+and announced on the PMIx mailing list at least four weeks in advance of the meeting. Approximately four weeks in advance of
 the meeting the Co-Chairs will announce the tentative agenda for review.
-The community has a two-week window of time to review and comment on
-the agenda. The agenda will be finalized two weeks before the quarterly
+The community has until two weeks before the quarterly meeting to review and comment on
+the agenda and PRs scheduled for vote or reading. During the review period, the contents of the agenda and PRs scheduled for vote or reading may be changed. The agenda will be finalized two weeks before the quarterly
 meeting at which point no further additions or modifications will be accepted.
 A PR posted for vote or reading in the ASC quarterly meeting must not have
 any modification of the content of the branch after the agenda finalization
 deadline. Comments on the PR are welcome at any time, but the content of the
 PR must be frozen to allow for community review of the stable text. For a
-formal reading, it is required that a PDF rendering of the changed document
-be sent to the chairs for distribution in the final agenda.
-
+formal reading or vote, it is required that a PDF rendering of the changed document
+be sent to the PMIx mailing list and to the Co-chairs for distribution in the final agenda.
 
 \hypertarget{modification-of-governance-rules}{%
 \subsubsection{Modification of Governance Rules}\label{modification-of-governance-rules}}


### PR DESCRIPTION
New PR to fix git-related problems with original governance PR #17. Text changes clarify the timeline for quarterly meeting announcements.

See https://github.com/pmix/governance/pull/17 for history of this change. 
