### PR TITLE
Revision exception votes for PRs (R2)

### DIFF
--- a/pmix_governance.tex
+++ b/pmix_governance.tex
@@ -320,6 +320,26 @@ ASC will use the following rules:
   as having been voted \emph{in absentia} in the official tally.
 \end{itemize}
 
+Revision Exception votes are special votes for PRs that have been modified
+after the review period deadline before a quarterly meeting 
+before a first vote or after having passed a first
+vote. Revision Exception votes may be called by the proposer to evaluate 
+whether the ASC is willing to proceed voting on the PR including the 
+modifications. 
+The idea behind Revision Exception votes is to maintain forward progress on
+PRs even if changes are made after the quarterly meeting deadlines or after
+a first vote.
+Normally, changes acceptable for Revision Exception votes
+are relatively minor and do not change the fundamentals of the PR. However,
+if a quorum of ASC voting-eligible members all vote affirmatively  
+for a Revision Exception vote, then the regular vote 
+for the PR may proceed for the text of the PR including the modifications. 
+A quorum of ASC voting-eligible members must be present and vote in the affirmative 
+without any negative votes for the Revision Exception vote to pass.
+If the Revision Exception vote does not pass, 
+the proposer must choose to re-read the PR with the modifications
+or to continue the normal vote without the modifications.
+
 Straw Polls are used in several places as a means of gauging
 community support for a proposal - e.g., in assessing acceptance for a
 new Provisional API. Straw Polls are conducted on an informal basis


### PR DESCRIPTION
This is a new PR to replace original governance PR#18 which had git-related problems. Text changes to add revision exception votes for minor changes to readings or voting items.

See https://github.com/pmix/governance/pull/18 for history of the changes associated with this PR