### PR TITLE
Update major release guidance

### DIFF
--- a/pmix_governance.tex
+++ b/pmix_governance.tex
@@ -529,21 +529,19 @@ on the community's web site and send an email announcing the release to
 the community mailing list. Minor releases, therefore, can occur on an
 at most a quarterly basis.
 
-Major release candidates must be approved during the ASC's annual
-face-to-face meeting. Release Managers must notify the Co-Chairs of a
-major release candidate a minimum of two quarters before the target
-approval meeting. The Co-Chairs will add an item to the agenda of each
-quarterly meeting for discussion and review of the document, and on the
-face-to-face meeting for vote on final approval. Once the ASC has voted
-its approval, the Release Managers shall post the new release on the
-community's web site and send an email announcing the release to the
-community mailing list. Should the ASC not approve the release,
-subsequent release candidates can be considered at upcoming regular ASC
-meetings - i.e., the major release candidate does not have to wait for
-the next annual face-to-face meeting for reconsideration. However, no
+Major release candidates can be approved during any ASC quarterly
+meeting. Release Managers must notify the Co-Chairs of a major release
+candidate a minimum of two quarters before the target approval
+meeting. The Co-Chairs will add an item to the agenda of each quarterly
+meeting for discussion and review of the document, and on the target
+meeting for vote on final approval. Once the ASC has voted its approval,
+the Release Managers shall post the new release on the community's web
+site and send an email announcing the release to the community mailing
+list. Should the ASC not approve the release, subsequent release
+candidates can be considered at upcoming ASC meetings. Note, no
 subsequent major release may begin the approval process until after the
-current candidate has been published. Major releases, therefore, can
-occur no more than once per year.
+current candidate has been published. Major releases shall not occur
+more than once per year.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Remove face-to-face meeting requirement for major release approval, and
updating surrounding text. Retain limit of one major release per year.